### PR TITLE
Fix duplicate reference causing TestFlight deployment error

### DIFF
--- a/CS342Application.xcodeproj/project.pbxproj
+++ b/CS342Application.xcodeproj/project.pbxproj
@@ -167,8 +167,7 @@
 				1A8C31D9297FCFF6002D6F2F /* HamedHekmat.swift */,
 				ABFEA6DA297C78FD00EF30AE /* AshleyGriffin.swift */,
 				F72C387F2980761200528574 /* ParthavShergill.swift */,
-				F565FA50297F19820043DB25 /* JustinWu.swift */,
-				ABFEA6DA297C78FD00EF30AE /* AshleyGriffin.swift */
+				F565FA50297F19820043DB25 /* JustinWu.swift */
 			);
 			path = MemberViews;
 			sourceTree = "<group>";

--- a/CS342Application.xcodeproj/project.pbxproj
+++ b/CS342Application.xcodeproj/project.pbxproj
@@ -261,10 +261,8 @@
 				A11A0B09297F9C8600E03791 /* AndyWang */,
 				2324B680297D972200C8D549 /* RajPabari */,
 				1A8C31D7297F95E1002D6F2F /* HamedHekmat */,
-				ABFEA6D8297C75FD00EF30AE /* AshleyGriffin */,
 				F7E62790297FA45B00200446 /* ParthavShergill */,
 				F565FA52297F29700043DB25 /* JustinWu */,
-				ABFEA6D8297C75FD00EF30AE /* AshleyGriffin */
 			);
 			productName = CS342Application;
 			productReference = 653A254D283387FE005D4D48 /* CS342Application.app */;


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Fix duplicate reference causing TestFlight deployment error

## :recycle: Current situation & Problem
TestFlight deployment is failing with the following error:

```
2023-01-28 14:48:41.863 xcodebuild[3891:24498] warning:  The file reference for "AshleyGriffin.swift" is a member of multiple groups ("MemberViews" and "MemberViews"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
```

## :bulb: Proposed solution
Removes the duplicate references causing this error.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

