### PR TITLE
Fix colliding paths error when cloning repository

### DIFF
--- a/CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackGround.JPG.license
+++ b/CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackGround.JPG.license
@@ -1,6 +1,0 @@
-
-This source file is part of the CS342 2023 Application project
-
-SPDX-FileCopyrightText: 2023 Stanford University
-
-SPDX-License-Identifier: MIT

--- a/CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackground.JPG.license
+++ b/CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackground.JPG.license
@@ -4,3 +4,4 @@ This source file is part of the CS342 2023 Application project
 SPDX-FileCopyrightText: 2023 Stanford University
 
 SPDX-License-Identifier: MIT
+

--- a/CS342MemberViews/Sources/AdamZhao/Resources/Sunsetbackground.JPG.license
+++ b/CS342MemberViews/Sources/AdamZhao/Resources/Sunsetbackground.JPG.license
@@ -1,6 +1,0 @@
-
-This source file is part of the CS342 2023 Application project
-
-SPDX-FileCopyrightText: 2023 Stanford University
-
-SPDX-License-Identifier: MIT


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Fixes colliding paths error when cloning repository

## :recycle: Current situation & Problem
When cloning the repository currently, git throws the following error. This error also prevents pushing new commits to the repository.

```
warning: the following paths have collided (e.g. case-sensitive paths
on a case-insensitive filesystem) and only one from the same
colliding group is in the working tree:

  'CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackGround.JPG.license'
  'CS342MemberViews/Sources/AdamZhao/Resources/SunsetBackground.JPG.license'
  'CS342MemberViews/Sources/AdamZhao/Resources/Sunsetbackground.JPG.license'
```

This is occurring because MacOS by default is a case-insensitive file system.

## :bulb: Proposed solution

The issue is resolved in this PR by removing the duplicate paths from the git tree.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

